### PR TITLE
Add pyproject with rerun dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # ik_project
+
+This project aims to provide forward and inverse kinematics solutions for robot models described in URDF. The results can be visualized using [Rerun](https://www.rerun.io/).
+
+## Setup
+
+Install the project in an isolated environment:
+
+```bash
+python -m pip install -e .
+```
+
+This will pull in the `rerun-sdk` dependency specified in `pyproject.toml`.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ik_project"
+version = "0.1.0"
+description = "URDF-based IK solving with Rerun visualization"
+authors = [{name = "Changsu Ha", email = "changsupersevere@gmail.com"}]
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "rerun-sdk[notebook]>=0.24.0"
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+


### PR DESCRIPTION
## Summary
- add a `pyproject.toml` defining the project and the `rerun-sdk` dependency
- expand README with short setup instructions

## Testing
- `python -m pip install -e .` *(fails: Could not fetch build dependencies due to no internet)*

------
https://chatgpt.com/codex/tasks/task_e_6886ffbd0cb48331b019796a0d3c08c6