### PR TITLE
Add Franka URDF visualizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,14 @@ Install the project in an isolated environment:
 python -m pip install -e .
 ```
 
-This will pull in the `rerun-sdk` dependency specified in `pyproject.toml`.
+This will pull in the dependencies specified in `pyproject.toml`.
 
+## Visualizing the Franka Emika arm
+
+To download the official `franka_description` package and visualize the robot in Rerun:
+
+```bash
+python -c "from ik_project.franka_visualizer import visualize_franka; visualize_franka()"
+```
+
+This will download the URDF and mesh files (if not already cached) and open a Rerun viewer showing the Panda robot.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,9 @@ authors = [{name = "Changsu Ha", email = "changsupersevere@gmail.com"}]
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
+    "requests>=2.0.0",
+    "urdfpy>=0.0.22",
+    "trimesh>=4.0.0",
     "rerun-sdk[notebook]>=0.24.0"
 ]
 

--- a/src/ik_project/franka_visualizer.py
+++ b/src/ik_project/franka_visualizer.py
@@ -1,0 +1,70 @@
+import io
+import zipfile
+from pathlib import Path
+from typing import Optional
+
+import requests
+from urdfpy import URDF
+import rerun as rr
+import trimesh
+
+
+def download_franka_description(dest: Path, branch: str = "main") -> Path:
+    """Download the franka_description repository as a zip file.
+
+    Parameters
+    ----------
+    dest:
+        Destination directory where the repository will be extracted.
+    branch:
+        Git branch to download. Defaults to ``main``.
+
+    Returns
+    -------
+    Path
+        Path to the root of the extracted repository.
+    """
+    dest.mkdir(parents=True, exist_ok=True)
+    zip_url = (
+        f"https://github.com/frankarobotics/franka_description/archive/refs/heads/{branch}.zip"
+    )
+    resp = requests.get(zip_url)
+    resp.raise_for_status()
+    with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
+        zf.extractall(dest)
+    return dest / f"franka_description-{branch}"
+
+
+def visualize_franka(repo_dir: Optional[Path] = None) -> None:
+    """Visualize the Franka Emika arm URDF using Rerun.
+
+    If ``repo_dir`` is ``None`` the franka_description repo is downloaded
+    automatically using :func:`download_franka_description`.
+    """
+
+    if repo_dir is None:
+        repo_dir = download_franka_description(Path.home()/".cache"/"franka_description")
+
+    urdf_path = repo_dir / "robots" / "panda_arm_hand.urdf"
+    robot = URDF.load(urdf_path)
+
+    rr.init("franka_urdf")
+
+    fk = robot.link_fk()
+
+    for link, tf in fk.items():
+        for i, visual in enumerate(link.visuals):
+            geom = visual.geometry
+            node_path = f"/{link.name}/{i}"
+            rr.log(node_path, rr.Transform3D(matrix=tf @ visual.origin))
+            if geom.mesh is not None:
+                mesh_path = repo_dir / geom.filename
+                mesh = trimesh.load_mesh(mesh_path)
+                rr.log(
+                    node_path,
+                    rr.Mesh3D(
+                        vertex_positions=mesh.vertices,
+                        indices=mesh.faces.reshape(-1),
+                    ),
+                )
+    rr.show()


### PR DESCRIPTION
## Summary
- add dependencies for URDF visualization
- add example function to download and render Franka robot in Rerun
- update README with usage instructions

## Testing
- `python -m pip install -e .` *(fails: Could not connect to pypi.org)*

------
https://chatgpt.com/codex/tasks/task_e_688704c3c20c83318df0e508be00d65d