### PR TITLE
Add CLI for Franka visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,27 @@ python -m pip install -e .
 
 This will pull in the dependencies specified in `pyproject.toml`.
 
-## Visualizing the Franka Emika arm
-
-To download the official `franka_description` package and visualize the robot in Rerun:
+If you prefer not to install the package, you can run the module directly by
+adding the `src` directory to `PYTHONPATH`:
 
 ```bash
-python -c "from ik_project.franka_visualizer import visualize_franka; visualize_franka()"
+PYTHONPATH=src python -m ik_project.franka_visualizer
 ```
 
-This will download the URDF and mesh files (if not already cached) and open a Rerun viewer showing the Panda robot.
+The first time you run the visualizer it will download the official
+`franka_description` repository.  If internet access is not available, you can
+download the repository manually and pass the path with the `--repo_dir`
+option.
+
+## Visualizing the Franka Emika arm
+
+To visualize the robot with Rerun after installing the dependencies, simply run
+
+```bash
+python -m ik_project.franka_visualizer
+```
+
+The command above downloads the URDF and mesh files (if not already cached) and
+opens a Rerun viewer showing the Panda robot.  Use the `--repo_dir` option to
+point to an existing `franka_description` checkout if you do not have internet
+access during execution.

--- a/src/ik_project/franka_visualizer.py
+++ b/src/ik_project/franka_visualizer.py
@@ -28,8 +28,11 @@ def download_franka_description(dest: Path, branch: str = "main") -> Path:
     zip_url = (
         f"https://github.com/frankarobotics/franka_description/archive/refs/heads/{branch}.zip"
     )
-    resp = requests.get(zip_url)
-    resp.raise_for_status()
+    try:
+        resp = requests.get(zip_url)
+        resp.raise_for_status()
+    except Exception as exc:
+        raise RuntimeError(f"Failed to download {zip_url}: {exc}") from exc
     with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
         zf.extractall(dest)
     return dest / f"franka_description-{branch}"
@@ -68,3 +71,18 @@ def visualize_franka(repo_dir: Optional[Path] = None) -> None:
                     ),
                 )
     rr.show()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Visualize the Franka Emika arm URDF using Rerun",
+    )
+    parser.add_argument(
+        "--repo_dir",
+        type=Path,
+        help="Existing franka_description directory to use instead of downloading",
+    )
+    args = parser.parse_args()
+    visualize_franka(args.repo_dir)


### PR DESCRIPTION
## Summary
- add a command line interface to `franka_visualizer`
- improve handling of network download errors
- expand README with instructions for running the visualizer in environments without installation or network access

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6888235206048331bad963812a6a9c39